### PR TITLE
게시판 api 만들기 - Data Rest 적용 및 조회 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Spring Data REST
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/study/boardproject/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/study/boardproject/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.study.boardproject.repository;
 
 import com.study.boardproject.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/study/boardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/study/boardproject/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.study.boardproject.repository;
 
 import com.study.boardproject.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,10 @@ spring:
 
   h2.console.enabled: false
   sql.init.mode: always
+  data:
+    rest:
+      base-path: /api
+      detection-strategy: annotated
 
 
 ---

--- a/src/test/java/com/study/boardproject/controller/DataRestTest.java
+++ b/src/test/java/com/study/boardproject/controller/DataRestTest.java
@@ -1,0 +1,78 @@
+package com.study.boardproject.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+// @WebMvcTest // 컨트롤러와 관련된 내용만 최소한으로 테스트 받기 때문에, Data Rest의 auto cofiguration을 넣지 않는다.
+@DisplayName("Data REST - API 테스트")
+@Transactional // Rollback
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    public void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        //given
+
+        //when &then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    public void givenNothing_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+        //given
+
+        //when &then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 → 댓글 리스트 조회")
+    @Test
+    public void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        //given
+
+        //when &then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    public void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        //given
+
+        //when &then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    public void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        //given
+
+        //when &then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data Rest로 서비스하고, 해당 api들의 존재 여부만 체크하게끔 통합테스트를 작성